### PR TITLE
pass path to node_modules to module loading funcs

### DIFF
--- a/lib/pzh_otherManager.js
+++ b/lib/pzh_otherManager.js
@@ -113,7 +113,7 @@ var Pzh_RPC = function (_parent) {
         self.rpcHandler.setSessionId (_parent.pzh_state.sessionId);
         self.discovery = new Discovery (self.rpcHandler, [self.registry]);
         self.registry.registerObject (self.discovery);
-        var serviceCache = wUtil.webinosService.checkForWebinosModules();
+        var serviceCache = wUtil.webinosService.checkForWebinosModules(path.join(__dirname, "../node_modules"));
         if (serviceCache !== []) {
             _parent.config.serviceCache = serviceCache;
             _parent.config.storeDetails("userData", "serviceCache", _parent.config.serviceCache);


### PR DESCRIPTION
fixes loading api modules that are installed with npm link.

Jira-issue: [WP-1018](http://jira.webinos.org/browse/WP-1018)
