### PR TITLE
Update Test API Get42 to register its contructor

### DIFF
--- a/node_modules/webinos-api-test/wrt/webinos.get42.js
+++ b/node_modules/webinos-api-test/wrt/webinos.get42.js
@@ -23,16 +23,14 @@
 	 * @param obj Object containing displayName, api, etc.
 	 */
 	TestModule = function(obj) {
-		this.base = WebinosService;
-		this.base(obj);
+		WebinosService.call(this, obj);
 		
 		this._testAttr = "HelloWorld";
 		this.__defineGetter__("testAttr", function (){
 			return this._testAttr + " Success";
 		});
 	};
-	
-	TestModule.prototype = new WebinosService;
+	_webinos.registerServiceConstructor("http://webinos.org/api/test", TestModule);
 	
 	/**
 	 * To bind the service.


### PR DESCRIPTION
The name for API module constructors is no longer hard coded, so APIs
have to register

Jira-issue: http://jira.webinos.org/browse/WP-1045
