### PR TITLE
remove null arg from storeDetails call

### DIFF
--- a/lib/pzh_provider.js
+++ b/lib/pzh_provider.js
@@ -82,7 +82,7 @@ var Provider = function (hostname, friendlyName) {
             var PzpDefaultConfig = require("../config.json");
             config.userPref.ports = PzpDefaultConfig.ports;
             config.storeDetails("userData", "userPref", config.userPref);
-            config.storeDetails(null,"metaData", config.metaData);
+            config.storeDetails("metaData", config.metaData);
             var signedCert, csr, cn;
             cn = config.metaData.webinosType + "CA:" + config.metaData.webinosName;
             if(config.cert.generateSelfSignedCertificate(config.metaData.webinosType+"CA", cn)) {
@@ -95,7 +95,7 @@ var Provider = function (hostname, friendlyName) {
                         logger.log ("*****"+config.metaData.webinosType+" Connection Certificate Signed by Master Certificate*****");
                         config.cert.internal.conn.cert = signedCert;
                         config.storeDetails(path.join("certificates", "internal"),"certificates", config.cert.internal);
-                        config.storeDetails(null, "crl", config.cert.crl);
+                        config.storeDetails("crl", config.cert.crl);
                         config.storeDetails("userData", "userDetails", config.cert.userData);
                         return true;
                     }
@@ -159,7 +159,7 @@ var Provider = function (hostname, friendlyName) {
     function addPzhDetails(uri, options) {
         server.addContext(uri, options);
         config.trustedList.pzh[uri] = {"address":hostname};
-        config.storeDetails(null, "trustedList", config.trustedList);
+        config.storeDetails("trustedList", config.trustedList);
     }
 
     /**

--- a/lib/pzh_tlsSessionHandling.js
+++ b/lib/pzh_tlsSessionHandling.js
@@ -328,8 +328,8 @@ var Pzh = function () {
         }
         if (self.config.trustedList.pzh[id]) {
             delete self.config.trustedList.pzh[id];
-            self.config.storeDetails(null, "trustedList", self.config.trustedList);
-            //self.config.storeDetails(null, "trustedList", self.config.trustedList);
+            self.config.storeDetails("trustedList", self.config.trustedList);
+            //self.config.storeDetails("trustedList", self.config.trustedList);
             self.pzh_state.logger.log("removed pzh "+ id+" from the trusted list ");
             if (self.config.cert.external[id]) {
                 delete self.config.cert.external[id];
@@ -363,7 +363,7 @@ var Pzh = function () {
             self.config.metaData.nickname = user.nickname;
             self.config.metaData.friendlyName = self.config.userData.name +" ("+ self.config.userData.authenticator + ")";
             self.config.userData.nickname = user.nickname;
-            self.config.storeDetails(null,"metaData", self.config.metaData);
+            self.config.storeDetails("metaData", self.config.metaData);
             self.config.storeDetails("userData","userDetails", self.config.userData);
             var signedCert, csr;
             var cn = self.config.metaData.webinosType + "CA:" + self.config.metaData.webinosName;
@@ -376,7 +376,7 @@ var Pzh = function () {
                         self.pzh_state.logger.log ("*****"+self.config.metaData.webinosType+" Connection Certificate Signed by Master Certificate*****");
                         self.config.cert.internal.conn.cert = signedCert;
                         self.config.storeDetails("certificates/internal","certificates", self.config.cert.internal);
-                        self.config.storeDetails(null, "crl", self.config.cert.crl);
+                        self.config.storeDetails("crl", self.config.cert.crl);
                         return true;
                     }
                 }

--- a/lib/pzh_webSessionHandling.js
+++ b/lib/pzh_webSessionHandling.js
@@ -387,7 +387,7 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
             }
             if (!userObj.config.trustedList.pzh.hasOwnProperty (name)) {
                 userObj.config.trustedList.pzh[name] = {};
-                userObj.config.storeDetails(null, "trustedList", userObj.config.trustedList);
+                userObj.config.storeDetails("trustedList", userObj.config.trustedList);
             }
             sendMsg( conn, obj.user, { type:"storeExternalCert", message:true });
         }
@@ -420,7 +420,7 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
             externalCerts:obj.message.externalPzh.pzhCerts.server,
             externalCrl  :obj.message.externalPzh.pzhCerts.crl,
             serverPort   :obj.message.externalPzh.pzhCerts.serverPort};
-        userObj.config.storeDetails(null, "untrustedList", userObj.config.untrustedCert);
+        userObj.config.storeDetails("untrustedList", userObj.config.untrustedCert);
         sendMsg (conn, obj.user, { type:"requestAddFriend", message:true });
     }
 
@@ -465,10 +465,10 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
             }
             if (!userObj.config.trustedList.pzh.hasOwnProperty (name)) {
                 userObj.config.trustedList.pzh[name] = {};
-                userObj.config.storeDetails(null, "trustedList", userObj.config.trustedList);
+                userObj.config.storeDetails("trustedList", userObj.config.trustedList);
             }
             delete userObj.config.untrustedCert[obj.message.externalUserId];
-            userObj.config.storeDetails(null, "untrustedList", userObj.config.untrustedCert);
+            userObj.config.storeDetails("untrustedList", userObj.config.untrustedCert);
         }
     }
 
@@ -503,7 +503,7 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
             //update the actual list.
             if (!userObj.config.trustedList.pzh.hasOwnProperty (friendpzh.config.metaData.serverName)) {
                 userObj.config.trustedList.pzh[friendpzh.config.metaData.serverName] = {};
-                userObj.config.storeDetails(null, "trustedList", userObj.config.trustedList);
+                userObj.config.storeDetails("trustedList", userObj.config.trustedList);
             }
 
             var id = pzhNicknameToUserId( userObj.config.userData.nickname, hostname, serverPort);
@@ -524,7 +524,7 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
                 externalCrl  :userObj.config.crl,
                 serverPort   :serverPort // TODO
             };
-            userObj.config.storeDetails(null, "untrustedList", userObj.config.untrustedCert);
+            userObj.config.storeDetails("untrustedList", userObj.config.untrustedCert);
             sendMsg(conn, obj.user, { type:"requestAddLocalFriend", message:true });
             return;
         } else {


### PR DESCRIPTION
fixes exception on path.join with node.js 0.10, which doesn't allow any
other args than strings.

Jira-issue: http://jira.webinos.org/browse/WP-980
