### PR TITLE
Fix certificate exchange and add invitation token support

### DIFF
--- a/lib/pzh_connectPzh.js
+++ b/lib/pzh_connectPzh.js
@@ -34,8 +34,9 @@ var Pzh_connectPzh = function () {
             var connPzh, connDetails;
             connDetails = options;
             connDetails.servername = to;
+            console.log(require('util').inspect(pzhDetails));
             connDetails.host = pzhDetails.host;
-            connDetails.port = pzhDetails.serverPort; //parseInt(pzhDetails.port);
+            connDetails.port = pzhDetails.port;
             logger.log ("connection from " + PzhObject.getSessionId() + " - to PZH " + connDetails.servername + " initiated at host " + connDetails.host + " and port " + connDetails.port);
             connPzh = require("tls").connect (connDetails, function () {
                 logger.log ("connection status : " + connPzh.authorized);

--- a/lib/pzh_provider.js
+++ b/lib/pzh_provider.js
@@ -171,11 +171,11 @@ var Provider = function (hostname, friendlyName) {
         var myKey, list = [];
         for (myKey in config.trustedList.pzh) {
             if (config.trustedList.pzh.hasOwnProperty(myKey) && myKey !== userId
-                && !userObj.config.trustedList.pzh.hasOwnProperty(myKey)) {
+                && !userObj.getTrustedList("pzh").hasOwnProperty(myKey)) {
                 list.push({url:myKey,
-                    username:pzhs[myKey].config.userData.name,
-                    email:pzhs[myKey].config.userData.email[0].value,
-                    nickname: pzhs[myKey].config.userData.nickname });
+                    username:pzhs[myKey].getUserData("name"),
+                    email:pzhs[myKey].getEmailId(),
+                    nickname: pzhs[myKey].getUserData("nickname") });
             }
         }
         return list;

--- a/lib/pzh_tlsSessionHandling.js
+++ b/lib/pzh_tlsSessionHandling.js
@@ -62,7 +62,7 @@ var Pzh = function () {
     PzhObject.getSignedCert    = function(id)  { console.log(id, config.cert.internal.signedCert); return (id? config.cert.internal.signedCert[id]: Object.keys(config.cert.internal.signedCert));};
     PzhObject.getRevokedCert   = function(id)  { return (id? config.cert.internal.revokedCert[id]: Object.keys(config.cert.internal.revokedCert));};
     PzhObject.getExternalCertificate= function(to){return (to?  config.cert.external[to] : Object.keys(config.cert.external));   };
-    PzhObject.getWebinosPorts  = function(id) { return (id? config.userPef[id]: config.userPref); };
+    PzhObject.getWebinosPorts  = function(id) { return (id? config.userPref.ports[id]: config.userPref.ports); };
     PzhObject.getUserData      = function(name){ return (name? config.userData[name]: config.userData);};
     PzhObject.getMetaData      = function(name){ return (name? config.metaData[name]: config.metaData);};
 
@@ -90,6 +90,9 @@ var Pzh = function () {
     };
     PzhObject.setPzhTrustedList   = function(name, friendlyName){
         if (!PzhObject.checkTrustedList(name)) {
+            if (typeof friendlyName == 'undefined' || friendlyName === null) {
+                friendlyName = name;
+            }
             config.trustedList.pzh[name] = {friendlyName: friendlyName};
             config.storeDetails( "trustedList", config.trustedList);
         }
@@ -104,16 +107,37 @@ var Pzh = function () {
             config.storeDetails( "untrustedList", config.untrustedCert);
         }
     };
+    PzhObject.checkInvitationToken = function(id) { 
+        if (id === null || typeof id === 'undefined' || !config.invitationTokens.hasOwnProperty(id) ) return false;
+        var expires = new Date(config.invitationTokens[id].expiryDate);
+        return expires > new Date();
+    };
+    PzhObject.addInvitationToken = function(token) { 
+        config.invitationTokens[token.linkId] = token;
+        config.storeDetails( "invitationTokens", config.invitationTokens);
+    };
+    PzhObject.removeInvitationToken = function(id) { 
+        if (config.invitationTokens.hasOwnProperty(id)) {
+            delete config.invitationTokens[id];
+            config.storeDetails( "invitationTokens", config.invitationTokens);
+        }
+    };
+    PzhObject.getInvitationToken = function(id) { 
+        if (config.invitationTokens.hasOwnProperty(id)) {
+            return config.invitationTokens[id];
+        }
+    };
     PzhObject.setExternalCertificate=function(name, configuration){
         if (!PzhObject.checkExternalCertificate(name)) {
             config.cert.external[name] = configuration;
-            config.storeDetails(require("path").join("certificate","external"), "certificates", config.cert.external);
+            console.log("Storing certificate details: " + JSON.stringify(config.cert.external));
+            config.storeDetails(require("path").join("certificates","external"), "certificates", config.cert.external);
         }
     };
     PzhObject.removeExternalCertificate=function(name){
         if (PzhObject.checkExternalCertificate(name)) {
             delete config.cert.external[name];
-            config.storeDetails(require("path").join("certificate","external"), "certificates", config.cert.external);
+            config.storeDetails(require("path").join("certificates","external"), "certificates", config.cert.external);
         }
     };
     PzhObject.revokeClientCert = function(id) {

--- a/lib/pzh_webSessionHandling.js
+++ b/lib/pzh_webSessionHandling.js
@@ -47,6 +47,10 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
         "addPzh"                :addPzh,
         "removePzh"             :removePzh,
         "checkPzh"              :checkPzh,
+// Managing invitation tokens
+        "checkToken"            :checkToken,
+        "deleteToken"           :deleteToken,
+        "registerToken"         :registerToken,
 // Certificate exchange
         "getAllPzh"             :getAllPzh,
         "getCertificates"       :getCertificates,
@@ -162,9 +166,42 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
     function getAllPzh (conn, obj, userObj) {
         sendMsg (conn, obj.user, { type:"getAllPzh", message:pzhFunctions.getAllPzh(userObj.getSessionId(), userObj) });
     }
+
+
+    // add an external certificate to this pzh
+    function addExternalCertificate(pzh, extName, extHost, extPort, extCerts, extCrl) {
+        var extPzh = {
+            id   : extName,
+            host : extHost, 
+            port : extPort,
+            externalCerts : extCerts,
+            externalCrl : extCrl
+        };
+        logger.log("Adding external certificate to " + pzh.getUserData("nickname") +"'s zone: " + util.inspect(extPzh));
+        pzh.setExternalCertificate(extName, extPzh);
+    }
+
+    function addUntrustedExternal(pzh, extName, extHost, extPort, extCerts, extCrl, extNickname, extEmail, extDisplayName, extFrom, extIdentifier) {
+        var extPzh = {
+            id           :extName,
+            host         :extHost,
+            port         :extPort,
+            externalCerts:extCerts,
+            externalCrl  :extCrl,
+            displayName  :extDisplayName,
+            from         :extFrom,
+            identifier   :extIdentifier,
+            email        :extEmail,
+            nickname     :extNickname            
+        };
+        logger.log("Adding unauthorised PZH certificates details to " + pzh.getUserData("nickname") +"'s zone: " + extPzh);
+        pzh.setUntrustedList(extName, extPzh);
+    }
+
     // First step in connect friend
     // The PZH we are trying to connect calls this to sends its certificate to connecting PZH
     function getCertificates (conn, obj, userObj) {
+        logger.log("Server port: " + userObj.getWebinosPorts("provider"));
         var result = {
             "provider"  :"provider-cert-data",
             "server"    :userObj.getMasterCertificate(),
@@ -177,28 +214,20 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
     // Second step
     // Connecting PZH stores certificates retrieved from another PZH
     function storeExternalCert (conn, obj, userObj) {
-        var url = require ("url").parse ("https://" + obj.message.externalPzh);
-        var name = pzhNicknameToUserId( obj.message.externalUserNickName,  url.hostname, url.port);
+        var url = require ("url").parse (obj.message.externalPzh);
+        var name = pzhNicknameToUserId( url.auth, url.hostname, url.port);
         logger.log (obj.user.displayName + " is now expecting external connection from " + name);
 
         if (userObj.checkExternalCertificate(name) && userObj.checkTrustedList(name)) {
             sendMsg (conn, obj.user, { type:"storeExternalCert", message:false }); // PZH ALREADY ENROLLED
         } else {
             if (!userObj.checkExternalCertificate(name)) {
-                var config = {
-                    id           :name,
-                    host         :url.hostname,
-                    port         :url.port ? url.port : 443,
-                    externalCerts:obj.message.externalCerts.server,
-                    externalCrl  :obj.message.externalCerts.crl,
-                    serverPort   :obj.message.externalCerts.serverPort
-                };
-                userObj.setExternalCertificate(name, config);
+                addExternalCertificate(userObj, name, url.hostname, obj.message.externalCerts.serverPort, obj.message.externalCerts.server, obj.message.externalCerts.crl);
                 var id = pzhNicknameToUserId( userObj.getUserData("nickname"), hostname, serverPort);
                 pzhFunctions.refreshPzh (id,  userObj.setConnParam());
 
             }
-            userObj.setPzhTrustedList(name);
+            userObj.setPzhTrustedList(name); // we don't have a friendly name.
             sendMsg( conn, obj.user, { type:"storeExternalCert", message:true });
         }
         // After this step OpenId authentication is triggered
@@ -206,28 +235,14 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
     // Third step
     // The PZH we are trying to connect calls this presumably this should return something unique
     function requestAddFriend (conn, obj, userObj) {
-        var externalUrl  = require ("url").parse (obj.message.externalPzh.externalPZHUrl);
+        var externalUrl  = require ("url").parse (obj.message.externalPzh.pzhAddress);
         var externalUser = obj.message.externalUser;
-        var externalId   = pzhNicknameToUserId( obj.message.externalPzh.externalNickname,  externalUrl.hostname, externalUrl.port);
+        var externalId   = pzhNicknameToUserId( externalUrl.auth,  externalUrl.hostname, externalUrl.port);
        
         //TODO: What if a malformed userId is given?
-        logger.log ("PZH TLS Server is now aware that the user " + externalUser.displayName + "(" + obj.message.externalPzh.externalNickname + ")"
-             + " with PZH details : " + obj.message.externalPzh.externalPZHUrl +
-            " has been authenticated and would like to be added to the list of trusted users to " +
-            userObj.getUserData("name") + "'s zone");
-
-        var config = {
-            email        :externalUser.emails[0].value,
-            displayName  :externalUser.displayName,
-            from         :externalUser.from,
-            identifier   :externalUser.identifier,
-            host         :externalUrl.hostname,
-            nickname     :obj.message.externalPzh.externalNickname,
-            port         :externalUrl.port ? externalUrl.port : 443,
-            externalCerts:obj.message.externalPzh.pzhCerts.server,
-            externalCrl  :obj.message.externalPzh.pzhCerts.crl,
-            serverPort   :obj.message.externalPzh.pzhCerts.serverPort};
-        userObj.setUntrustedList(externalId, config);
+        addUntrustedExternal(userObj, externalId, externalUrl.hostname, obj.message.externalPzh.pzhCerts.serverPort, 
+                            obj.message.externalPzh.pzhCerts.server, obj.message.externalPzh.pzhCerts.crl, externalUser.nickname, 
+                            externalUser.emails[0].value, externalUser.displayName, externalUser.from, externalUser.identifier );
         sendMsg (conn, obj.user, { type:"requestAddFriend", message:true });
     }
     // Fourth Step
@@ -248,7 +263,9 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
             var details = userObj.getUntrustedList(obj.message.externalUserId), name = obj.message.externalUserId;
             userObj.setPzhTrustedList(name);
             if (!userObj.checkExternalCertificate(name)) {
-                userObj.setExternalCertificate(name, details);
+                
+                addExternalCertificate(userObj, name, details.host, details.port, details.externalCerts, details.externalCrl);
+
                 var id = pzhNicknameToUserId(userObj.getUserData("nickname"), hostname, serverPort);
                 var certificateParam = userObj.setConnParam();
                 pzhFunctions.refreshPzh (id, certificateParam);
@@ -277,15 +294,7 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
         var friendpzh;
         if ((friendpzh = findExistingUserFromNickname(obj.message.externalNickname))) {
             // add the 'friend' to the current user's list of known people.
-            logger.log("Adding " + obj.message.externalNickname + " as an external user to " + userObj.getEmailId() + "'s zone");
-            var config = {
-                id           :friendpzh.getSessionId(),
-                port         :port,
-                externalCerts:friendpzh.getMasterCertificate(),
-                externalCrl  :friendpzh.getCRL(),
-                serverPort   :serverPort // TODO
-            };
-            userObj.setExternalCertificate(friendpzh.getSessionId(), config);
+            addExternalCertificate(userObj, friendpzh.getSessionId(), hostname, serverPort, friendpzh.getMasterCertificate(), friendpzh.getCRL());
 
             //update the actual list.
             userObj.setPzhTrustedList(friendpzh.getSessionId(), friendpzh.getFriendlyName());
@@ -294,25 +303,48 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
 
             // add the current user to the friend's list of untrusted people.
             // the friend will later approve or reject the request.
-            logger.log("Adding " + userObj.getEmailId() + " as an external user to " + obj.message.externalNickname + "'s zone");
-            config = {
-                email        :userObj.getEmailId(),
-                displayName  :userObj.getUserData("name"),
-                from         :userObj.getUserData("authenticator"),
-                identifier   :userObj.getUserData("identifier"),
-                host         :hostname,
-                port         :port,
-                name         :userObj.getSessionId(),
-                externalCerts:userObj.getMasterCertificate(),
-                externalCrl  :userObj.getCRL(),
-                serverPort   :serverPort
-            };
-            friendpzh.setUntrustedList(userObj.getSessionId(), config);
+            addUntrustedExternal(friendpzh, userObj.getSessionId(), hostname, serverPort, userObj.getMasterCertificate(), 
+                userObj.getCRL(), userObj.getUserData("nickname"), userObj.getEmailId(), userObj.getUserData("name"), 
+                userObj.getUserData("authenticator"), userObj.getUserData("identifier"));
+
             sendMsg(conn, obj.user, { type:"requestAddLocalFriend", message:true });
         } else {
             sendMsg(conn, obj.user, { type:"requestAddLocalFriend", message:false });
         }
     }
+
+    function registerToken(conn, obj, userObj) {
+        var crypto = require('crypto');
+        var token = {
+            "nickname" : userObj.getUserData("nickname"),
+            "identifier" :  userObj.getUserData("identifier"),
+            "linkId" : (crypto.randomBytes(100).toString("Base64")),
+            "expiryDate" : new Date( + new Date + 12096e5),
+            "external" : obj.message.externalDetails
+        }
+        userObj.addInvitationToken(token);
+        sendMsg(conn, obj.user, { type:"registerToken", message:token.linkId});
+    }
+
+    function checkToken(conn, obj, userObj) {
+        if (userObj.checkInvitationToken(obj.message.token)) {
+            var validToken = userObj.getInvitationToken(obj.message.token);
+            sendMsg(conn, obj.user, { type:"checkToken", message: {result : true, tokenDetails : validToken } } );
+        } else {
+            logger.log("Invalid token: " + obj.message.token);
+            sendMsg(conn, obj.user, { type:"checkToken", message: {result : false} } );
+        }
+    }
+
+    function deleteToken(conn, obj, userObj) {
+        if (userObj.checkInvitationToken(obj.message.token)) {
+            userObj.removeInvitationToken(obj.message.token);
+            sendMsg(conn, obj.user, { type:"deleteToken", message: {result : true, tokenDetails : obj.message.token } } );
+        } else {
+            sendMsg(conn, obj.user, { type:"deleteToken", message: {result : false } } );
+        }
+    }
+
     function addPzh(conn, obj, userObj) {
         logger.log("Request add PZH: \n" + util.inspect(obj) + "\nFrom user: \n" + util.inspect(obj.user));
         var nickname = obj.message.nickname;
@@ -337,8 +369,8 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
         var result = (user !== null);
         var userConfig = null;
         if (result) {
-            userConfig = user && user.getMetaData();
-        }
+            userConfig = user && user.getUserData();
+        } 
         sendMsg(conn, obj.user, {
             "type"   : "checkPzh",
             "message": {
@@ -461,11 +493,12 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
                     messageType[message.message.type].apply (this, [conn, message]);
                     return;
                 } 
-                var userObj = null;
-                if (message.message.type === "getCertificates" || message.message.type === "requestAddFriend") {
-                    userObj = findExistingUserFromNickname(message.user.nickname); 
-                } else {
-                    userObj = findExistingUserFromId (message.user.identifier);                
+                // we'll search for the user based on their nickname or their identifier, we don't care (should we?)
+                // TODO: Refactor to make this more sensible.  
+                // Sometimes we don't have an authenticated user, we're only acting on their behalf, so Id doesn't work.
+                var userObj = findExistingUserFromId (message.user.identifier);
+                if (userObj === null) {
+                    userObj = findExistingUserFromNickname(message.user.nickname);
                 }
                 if (userObj) {
                     messageType[message.message.type].apply(userObj, [conn, message, userObj]);


### PR DESCRIPTION
This pull request adds initial support for "invitations" - one personal zone hub issuing an invitation that anyone else can click on to connect the two personal zones.

These changes are linked closely to PZH Web Server changes too.

On this PR, I just add support for persistent tokens, generated and stored on the web server for each user. There are also some improvements in stability.

Jira issue: WP-852
