### PR TITLE
Fix enrolment on non-standard ports.

### DIFF
--- a/lib/pzh_pzpEnrollment.js
+++ b/lib/pzh_pzpEnrollment.js
@@ -55,10 +55,14 @@ var Pzh_pzpEnroll = function () {
                 // Add PZP in list of master certificates as PZP will sign connection certificate at its end.
                 refreshCert(PzhObject.getSessionId(), PzhObject.setConnParam());
                 // Send signed certificate and master certificate to PZP
-                var payload = {"clientCert":PzhObject.getSignedCert(pzpId),
-                    "masterCert":PzhObject.getMasterCertificate(),
-                    "masterCrl" :PzhObject.getCRL(),
-                    "friendlyName": PzhObject.getFriendlyName()};
+                console.log("Getting webinos port: " + PzhObject.getWebinosPorts("provider"));
+                var payload = {
+                    "clientCert"  :PzhObject.getSignedCert(pzpId),
+                    "masterCert"  :PzhObject.getMasterCertificate(),
+                    "masterCrl"   :PzhObject.getCRL(),
+                    "friendlyName":PzhObject.getFriendlyName(),
+                    "serverPort"  :PzhObject.getWebinosPorts("provider")
+                };
                 return PzhObject.prepMsg(pzpId,"signedCertByPzh", payload);
 
             } else {


### PR DESCRIPTION
The PZH will now tell an enrolling PZP which port to use to connect.

Related: https://github.com/webinos/webinos-pzp/pull/35

Jira issue: WP-852
