### PR TITLE
Remove stale invitation tokens from a personal zone hub

### DIFF
--- a/lib/pzh_tlsSessionHandling.js
+++ b/lib/pzh_tlsSessionHandling.js
@@ -115,6 +115,7 @@ var Pzh = function () {
     PzhObject.addInvitationToken = function(token) { 
         config.invitationTokens[token.linkId] = token;
         config.storeDetails( "invitationTokens", config.invitationTokens);
+        PzhObject.purgeOldInvitationTokens();
     };
     PzhObject.removeInvitationToken = function(id) { 
         if (config.invitationTokens.hasOwnProperty(id)) {
@@ -122,6 +123,13 @@ var Pzh = function () {
             config.storeDetails( "invitationTokens", config.invitationTokens);
         }
     };
+    PzhObject.purgeOldInvitationTokens = function() {
+        for (var tokenId in config.invitationTokens) {
+            if (!PzhObject.checkInvitationToken(tokenId)) {
+                PzhObject.removeInvitationToken(tokenId);
+            }
+        }
+    }
     PzhObject.getInvitationToken = function(id) { 
         if (config.invitationTokens.hasOwnProperty(id)) {
             return config.invitationTokens[id];


### PR DESCRIPTION
Add a function to delete invitation tokens that have expired.

Jira issue: WP-852
