### PR TITLE
Fix invitation-based certificate exchange: auto-connect after invite.

### DIFF
--- a/lib/pzh_webSessionHandling.js
+++ b/lib/pzh_webSessionHandling.js
@@ -227,7 +227,9 @@ var pzhWI = function (conn, pzhs, hostname, port, serverPort, pzhFunctions) {
                 addExternalCertificate(userObj, name, url.hostname, obj.message.externalCerts.serverPort, obj.message.externalCerts.server, obj.message.externalCerts.crl);
                 var id = pzhNicknameToUserId( userObj.getUserData("nickname"), hostname, serverPort);
                 pzhFunctions.refreshPzh (id,  userObj.setConnParam());
-
+                if (obj.message.connectImmediately) {
+                    userObj.connectOtherPZH (name, userObj.setConnParam());
+                }
             }
             userObj.setPzhTrustedList(name); // we don't have a friendly name.
             sendMsg( conn, obj.user, { type:"storeExternalCert", message:true });


### PR DESCRIPTION
Previously, invitations were working, but all that would happen was
certificates were exchanged.  No TLS connection was established.  This has
been fixed by adding some parameters to the 'storeExternalCert' message.

Jira issue: WP-852
