### PR TITLE
Fix filtering for cache === false

### DIFF
--- a/lib/pzh_cleanUp.js
+++ b/lib/pzh_cleanUp.js
@@ -36,7 +36,6 @@ var Pzh_CleanUp = function() {
         if(id) {
             logger.log ("removing route for " + id);
             PzhObject.clearConnectedDeviceDetails(id);
-            PzhObject.discovery.removeRemoteServiceObjects(id);
             //PzhObject.synchronizationStartAll();
         }
     };

--- a/lib/pzh_serviceHandler.js
+++ b/lib/pzh_serviceHandler.js
@@ -65,10 +65,13 @@ var PzhServiceHandler = function(){
     this.sendFoundServices = function (validMsgObj) {
         logger.log ("trying to send webinos services from this RPC handler to " + validMsgObj.from + "...");
         var services = PzhObject.discovery.getAllServices(validMsgObj.from);
-        var msg = PzhObject.prepMsg(validMsgObj.from, "foundServices", services);
+        var connectedServices = services.filter(function(svc) {
+          return svc.serviceAddress === PzhObject.getSessionId() || PzhObject.checkConnectedPzh(svc.serviceAddress) || PzhObject.checkConnectedPzp(svc.serviceAddress);
+        });
+        var msg = PzhObject.prepMsg(validMsgObj.from, "foundServices", connectedServices);
         msg.payload.id = validMsgObj.payload.message.id;
         PzhObject.sendMessage (msg, validMsgObj.from);
-        logger.log ("sent " + (services && services.length) || 0 + " Webinos Services from this rpc handler.");
+        logger.log ("sent " + (connectedServices && connectedServices.length) || 0 + " Webinos Services from this rpc handler.");
     };
 
     /**

--- a/lib/pzh_tlsSessionHandling.js
+++ b/lib/pzh_tlsSessionHandling.js
@@ -565,6 +565,7 @@ var Pzh = function (hostname) {
             config.loadCertificates(config.cert);
             logger.addId (uri && config.trustedList[uri] && config.trustedList[uri].nickname);
             PzhObject.setMessageHandler_RPC ();
+            PzhObject.storeServiceCache(config.serviceCache);
             return ({cert: PzhObject.setConnParam(), uri: uri});
         } catch (err) {
             logger.error(err);


### PR DESCRIPTION
The 'live' findservices functionality was completely broken.
- remoteServiceObjects was only populated if the service cache was sync'd (which it isn't most of the time since nothing has changed.
- when a PZP goes offline, it's services are removed from the remoteServiceObjects, but the services aren't re-added when the PZP re-connects
- the foundServices functionality wasn't actually checking if the entity is connected.

http://jira.webinos.org/browse/WP-1251
